### PR TITLE
feat: connect log processing execution flow

### DIFF
--- a/src/log_processing.py
+++ b/src/log_processing.py
@@ -244,14 +244,18 @@ def print_html_entries(data):
 def run(args=None):
     parser = build_parser()
     parsed_args = parser.parse_args(args)
-
     configure_logging(parsed_args.log_level)
+
+    logging.info("Start of log processing")
 
     lines = sys.stdin.readlines()
     data = read_log(lines)
+
     display_log(data)
     display_statistics(data)
     print_html_entries(data)
+
+    logging.info("Finish of log processing")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #44

Connected the full execution flow in log_processing.py:
- added start and finish execution logs
- read input from standard input
- parse input before displaying results
- kept reporting/statistics in the correct order
- verified the pipeline works with empty input

How tested:
- python3 src/log_processing.py < src/log.txt
- python3 src/log_processing.py DEBUG < src/log.txt
- printf '' | python3 src/log_processing.py