### PR TITLE
feat: add log entry object parsing

### DIFF
--- a/src/log_processing.py
+++ b/src/log_processing.py
@@ -64,27 +64,67 @@ class LogEntry:
         return self.bytes_sent / 1024
     
 
-def parse_timestamp(ts_string):
-    parts = ts_string.split(' ')
-    parts = parts[0].split(':')
-    
-    hour = int(parts[1])
-    minute = int(parts[2])
-    second = int(parts[3])
+from datetime import datetime
 
-    date_fields = parts[0].split('/')
-    day = int(date_fields[0])
-    month_str = date_fields[1]
-    year = int(date_fields[2])
+def parse_timestamp(ts_string):
+    ts_string = ts_string.strip()
+    ts_string = ts_string.strip("[]")
+    ts_string = ts_string.split(" ")[0]
+
+    date_part, time_part = ts_string.split(":")[0], ":".join(ts_string.split(":")[1:])
+
+    day, month_str, year = date_part.split("/")
+    hour, minute, second = time_part.split(":")
 
     months = {
-        'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
-        'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12
+        "Jan": 1, "Feb": 2, "Mar": 3, "Apr": 4,
+        "May": 5, "Jun": 6, "Jul": 7, "Aug": 8,
+        "Sep": 9, "Oct": 10, "Nov": 11, "Dec": 12
     }
-    
-    return datetime(year, months[month_str], day, hour, minute, second)
+
+    return datetime(
+        int(year),
+        months[month_str],
+        int(day),
+        int(hour),
+        int(minute),
+        int(second)
+    )
+
+
+def parse_log_line(line):
+    stripped_line = line.strip()
+
+    if not stripped_line:
+        return None
+
+    parts = stripped_line.split()
+
+    ip_address = parts[0]
+    timestamp = parse_timestamp(parts[3] + " " + parts[4])
+    method = parts[5].strip('"')
+    path = parts[6]
+    protocol = parts[7].strip('"')
+    status = int(parts[8])
+    bytes_sent = int(parts[9])
+
+    return LogEntry(ip_address, timestamp, method, path, protocol, status, bytes_sent)
    
-    
+
+def read_log_objects(lines):
+    logging.debug("Read %d raw lines from stdin", len(lines))
+
+    entries = []
+
+    for line in lines:
+        entry = parse_log_line(line)
+        if entry is not None:
+            entries.append(entry)
+
+    logging.debug("Parsed %d log entries into LogEntry objects", len(entries))
+    return entries
+
+
 def parse_line_to_logentry(line):
     parts = line.split()
     

--- a/tests/test_log_processing.py
+++ b/tests/test_log_processing.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import unittest
+from datetime import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+from log_processing import LogEntry, parse_timestamp, parse_log_line, read_log_objects
+
+
+class TestLogProcessing(unittest.TestCase):
+    def test_parse_timestamp_returns_datetime(self):
+        result = parse_timestamp("[03/Jan/2026:02:14:55 +0100]")
+        expected = datetime(2026, 1, 3, 2, 14, 55)
+        self.assertEqual(result, expected)
+
+    def test_parse_log_line_returns_log_entry_object(self):
+        line = '185.23.54.12 - - [03/Jan/2026:02:14:55 +0100] "GET /home HTTP/1.1" 200 1823'
+        entry = parse_log_line(line)
+
+        self.assertIsInstance(entry, LogEntry)
+        self.assertEqual(entry.path, "/home")
+        self.assertEqual(entry.status, 200)
+        self.assertEqual(entry.bytes_sent, 1823)
+
+    def test_read_log_objects_returns_list_of_objects(self):
+        lines = [
+            '185.23.54.12 - - [03/Jan/2026:02:14:55 +0100] "GET /home HTTP/1.1" 200 1823\n',
+            '77.91.204.33 - - [15/Feb/2026:18:45:12 +0000] "POST /api/login HTTP/1.1" 401 642\n',
+            '\n'
+        ]
+
+        result = read_log_objects(lines)
+
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(isinstance(entry, LogEntry) for entry in result))
+        self.assertEqual(result[0].path, "/home")
+        self.assertEqual(result[1].status, 401)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #57

Implemented:
- parse_timestamp() for log timestamps
- parse_log_line() returning LogEntry objects
- read_log_objects() returning a list of LogEntry objects
- unit tests for timestamp parsing and log object creation

Tests run:
python3 -m unittest tests/test_log_processing.py