### PR TITLE
feat: implement ip_find for active IP addresses

### DIFF
--- a/src/lab5.py
+++ b/src/lab5.py
@@ -238,6 +238,7 @@ def count_requests_by_ip(data, ip_address):
     request_counts = requests_per_ip(data)
     return request_counts.get(IPv4Address(ip_address), 0)
 
+
 def ip_find(data, most_active=True):
     """Return IP addresses with the highest or lowest number of requests."""
     request_counts = requests_per_ip(data)
@@ -256,6 +257,24 @@ def ip_find(data, most_active=True):
             result.append(ip_address)
 
     return result
+
+
+def longest_request(data):
+    """Return the longest request string together with its IP address."""
+    if not data:
+        return None
+
+    longest_entry = data[0]
+    longest_request_string = f"{longest_entry.method} {longest_entry.path}"
+
+    for entry in data[1:]:
+        request_string = f"{entry.method} {entry.path}"
+
+        if len(request_string) > len(longest_request_string):
+            longest_entry = entry
+            longest_request_string = request_string
+
+    return longest_request_string, longest_entry.ip
 
 
 def calculate_total_bytes_sent(data):

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -238,6 +238,25 @@ def count_requests_by_ip(data, ip_address):
     request_counts = requests_per_ip(data)
     return request_counts.get(IPv4Address(ip_address), 0)
 
+def ip_find(data, most_active=True):
+    """Return IP addresses with the highest or lowest number of requests."""
+    request_counts = requests_per_ip(data)
+
+    if not request_counts:
+        return []
+
+    if most_active:
+        searched_count = max(request_counts.values())
+    else:
+        searched_count = min(request_counts.values())
+
+    result = []
+    for ip_address, count in request_counts.items():
+        if count == searched_count:
+            result.append(ip_address)
+
+    return result
+
 
 def calculate_total_bytes_sent(data):
     """Return total bytes sent to the user."""

--- a/tests/test_lab5.py
+++ b/tests/test_lab5.py
@@ -6,7 +6,7 @@ from ipaddress import IPv4Address
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
-from lab5 import LogEntry, parse_timestamp, parse_line_to_logentry, read_log
+from lab5 import LogEntry, parse_timestamp, parse_line_to_logentry, read_log, ip_find
 
 
 class TestLogProcessing(unittest.TestCase):
@@ -39,6 +39,49 @@ class TestLogProcessing(unittest.TestCase):
         self.assertEqual(result[0].path, "/home")
         self.assertEqual(result[1].status, 401)
 
+    def test_ip_find_returns_most_active_ips(self):
+        lines = [
+            '185.23.54.12 - - [03/Jan/2026:02:14:55 +0100] "GET /home HTTP/1.1" 200 1823\n',
+            '185.23.54.12 - - [03/Jan/2026:02:15:55 +0100] "GET /about HTTP/1.1" 200 1000\n',
+            '77.91.204.33 - - [15/Feb/2026:18:45:12 +0000] "POST /api/login HTTP/1.1" 401 642\n',
+        ]
+
+        data = read_log(lines)
+        result = ip_find(data)
+
+        self.assertEqual(result, [IPv4Address("185.23.54.12")])
+
+    def test_ip_find_returns_least_active_ips(self):
+        lines = [
+            '185.23.54.12 - - [03/Jan/2026:02:14:55 +0100] "GET /home HTTP/1.1" 200 1823\n',
+            '185.23.54.12 - - [03/Jan/2026:02:15:55 +0100] "GET /about HTTP/1.1" 200 1000\n',
+            '77.91.204.33 - - [15/Feb/2026:18:45:12 +0000] "POST /api/login HTTP/1.1" 401 642\n',
+        ]
+
+        data = read_log(lines)
+        result = ip_find(data, most_active=False)
+
+        self.assertEqual(result, [IPv4Address("77.91.204.33")])
+
+    def test_ip_find_returns_many_ips_when_tied(self):
+        lines = [
+            '185.23.54.12 - - [03/Jan/2026:02:14:55 +0100] "GET /home HTTP/1.1" 200 1823\n',
+            '77.91.204.33 - - [15/Feb/2026:18:45:12 +0000] "POST /api/login HTTP/1.1" 401 642\n',
+        ]
+
+        data = read_log(lines)
+        result = ip_find(data)
+
+        self.assertEqual(
+            result,
+            [IPv4Address("185.23.54.12"), IPv4Address("77.91.204.33")]
+        )
+
+    def test_ip_find_returns_empty_list_for_empty_data(self):
+        result = ip_find([])
+
+        self.assertEqual(result, [])
+    
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lab5.py
+++ b/tests/test_lab5.py
@@ -6,7 +6,7 @@ from ipaddress import IPv4Address
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
-from lab5 import LogEntry, parse_timestamp, parse_line_to_logentry, read_log, ip_find
+from lab5 import LogEntry, parse_timestamp, parse_line_to_logentry, read_log, ip_find,  longest_request
 
 
 class TestLogProcessing(unittest.TestCase):
@@ -81,6 +81,40 @@ class TestLogProcessing(unittest.TestCase):
         result = ip_find([])
 
         self.assertEqual(result, [])
+
+    def test_longest_request_returns_request_string_and_ip(self):
+        lines = [
+            '185.23.54.12 - - [03/Jan/2026:02:14:55 +0100] "GET /home HTTP/1.1" 200 1823\n',
+            '77.91.204.33 - - [15/Feb/2026:18:45:12 +0000] "POST /api/very/long/login/path HTTP/1.1" 401 642\n',
+            '91.12.33.44 - - [20/Mar/2026:10:20:11 +0000] "GET /about HTTP/1.1" 200 500\n',
+        ]
+
+        data = read_log(lines)
+        result = longest_request(data)
+
+        self.assertEqual(
+            result,
+            ("POST /api/very/long/login/path", IPv4Address("77.91.204.33"))
+        )
+
+    def test_longest_request_returns_none_for_empty_data(self):
+        result = longest_request([])
+
+        self.assertIsNone(result)
+
+    def test_longest_request_can_return_first_when_tied(self):
+        lines = [
+            '185.23.54.12 - - [03/Jan/2026:02:14:55 +0100] "GET /same HTTP/1.1" 200 1823\n',
+            '77.91.204.33 - - [15/Feb/2026:18:45:12 +0000] "GET /same HTTP/1.1" 200 642\n',
+        ]
+
+        data = read_log(lines)
+        result = longest_request(data)
+
+        self.assertEqual(
+            result,
+            ("GET /same", IPv4Address("185.23.54.12"))
+        )
     
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #74
Closes #75

Implemented Lab05 functions: ip_find() and longest_request().

Changes:
- added ip_find(data, most_active=True)
- returns IPs with the highest request count by default
- returns IPs with the lowest request count when most_active=False
- handles ties by returning all matching IP addresses
- added longest_request(data)
- returns the longest request string together with its IP address
- returns None for empty input
- added unit tests for ip_find() and longest_request()