### PR TITLE
Feature/lab9 subnet browser filters

### DIFF
--- a/src/lab9/lab9.py
+++ b/src/lab9/lab9.py
@@ -29,7 +29,8 @@ LOG_LINE_PATTERN = re.compile(
     r"\[(?P<timestamp>[^\]]+)\]\s+"
     r'"(?P<request_header>[^"]+)"\s+'
     r"(?P<status>\d{3})\s+"
-    r"(?P<bytes_sent>\d+|-)\s*$"
+    r"(?P<bytes_sent>\d+|-)"
+    r'(?:\s+(?:"[^"]*"\s+)?"(?P<user_agent>[^"]*)")?\s*$'
 )
 REQUEST_HEADER_PATTERN = re.compile(
     r"^(?P<method>[A-Z]+)\s+"
@@ -40,14 +41,15 @@ REQUEST_HEADER_PATTERN = re.compile(
 
 class LogEntry:
     def __init__(
-            self,
-            ip=None,
-            timestamp=None,
-            method=None,
-            path="",
-            protocol=None,
-            status=0,
-            bytes_sent=0,
+        self,
+        ip=None,
+        timestamp=None,
+        method=None,
+        path="",
+        protocol=None,
+        status=0,
+        bytes_sent=0,
+        user_agent="",
     ):
         self.ip = IPv4Address(ip)
         self.timestamp = timestamp
@@ -56,6 +58,7 @@ class LogEntry:
         self.protocol = protocol
         self.status = status
         self.bytes_sent = bytes_sent
+        self.user_agent = user_agent
 
     @property
     def request_header(self):
@@ -149,6 +152,7 @@ def parse_log_line(line):
         request_match.group("protocol"),
         int(log_match.group("status")),
         bytes_sent,
+        log_match.group("user_agent") or "",
     )
 
 
@@ -491,6 +495,30 @@ def print_requests_from_subnet(entries, lines_per_page, input_func=input):
     return len(matching_entries)
 
 
+def requests_from_browser(entries, browser):
+    """Return requests issued by selected browser."""
+    selected_browser = browser.lower()
+    result = []
+
+    for entry in entries:
+        if selected_browser in entry.user_agent.lower():
+            result.append(entry)
+
+    return result
+
+
+def print_requests_from_browser(entries, browser):
+    """Print requests issued by selected browser."""
+    matching_entries = requests_from_browser(entries, browser)
+
+    print(f"Requests from browser {browser}: {len(matching_entries)}")
+
+    for entry in matching_entries:
+        print(entry)
+
+    return len(matching_entries)
+
+
 def print_requests_from_config_ip(data, ip_address):
     """Print all requests sent from the configured IP address."""
     target_ip = IPv4Address(ip_address)
@@ -652,6 +680,7 @@ def run(args=None):
 
     lines_per_page = int(display_settings["lines_per_page"])
     print_requests_from_subnet(data, lines_per_page)
+    print_requests_from_browser(data, display_settings["browser"])
 
 #    display_log(data)
 #    display_statistics(data)

--- a/src/lab9/lab9.py
+++ b/src/lab9/lab9.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 CONFIG_FILE = Path(__file__).with_name("lab9.config")
 CONFIG_ENCODING = "utf-8"
+STUDENT_INDEX = 284210
+SUBNET_IP = "185.0.0.0"
 LOG_LINE_PATTERN = re.compile(
     r"^(?P<ip>\d{1,3}(?:\.\d{1,3}){3})\s+\S+\s+\S+\s+"
     r"\[(?P<timestamp>[^\]]+)\]\s+"
@@ -436,6 +438,59 @@ def entries_from_network(data, network_text):
     return result
 
 
+def subnet_mask_length(student_index=STUDENT_INDEX):
+    """Return subnet mask length calculated from student index."""
+    return student_index % 16 + 8
+
+
+def is_ip_in_subnet(ip_address, subnet_ip=SUBNET_IP):
+    """Check if IP address belongs to the hard-coded subnet."""
+    network_text = f"{subnet_ip}/{subnet_mask_length()}"
+    network = IPv4Network(network_text, strict=False)
+    return IPv4Address(ip_address) in network
+
+
+def requests_from_subnet(entries):
+    """Return requests sent from the hard-coded subnet."""
+    result = []
+
+    for entry in entries:
+        if is_ip_in_subnet(entry.ip):
+            result.append(entry)
+
+    return result
+
+
+def print_entries_with_pagination(entries, lines_per_page, input_func=input):
+    """Print entries and pause after each page."""
+    if lines_per_page <= 0:
+        raise ValueError("lines_per_page must be greater than zero")
+
+    for index, entry in enumerate(entries, start=1):
+        print(entry)
+
+        if index % lines_per_page == 0 and index < len(entries):
+            input_func("Press Enter to display more...")
+
+
+def print_requests_from_subnet(entries, lines_per_page, input_func=input):
+    """Print all requests sent from the hard-coded subnet."""
+    matching_entries = requests_from_subnet(entries)
+
+    print(
+        "Requests from subnet "
+        f"{SUBNET_IP}/{subnet_mask_length()}: {len(matching_entries)}"
+    )
+
+    print_entries_with_pagination(
+        matching_entries,
+        lines_per_page,
+        input_func,
+    )
+
+    return len(matching_entries)
+
+
 def print_requests_from_config_ip(data, ip_address):
     """Print all requests sent from the configured IP address."""
     target_ip = IPv4Address(ip_address)
@@ -594,6 +649,9 @@ def run(args=None):
 
     lines = get_log_lines(parsed_args.filename)
     data = read_log(lines)
+
+    lines_per_page = int(display_settings["lines_per_page"])
+    print_requests_from_subnet(data, lines_per_page)
 
 #    display_log(data)
 #    display_statistics(data)

--- a/tests/test_lab9.py
+++ b/tests/test_lab9.py
@@ -11,10 +11,13 @@ sys.path.insert(
 
 from lab9 import (
     LogEntry,
+    parse_log_line,
     subnet_mask_length,
     is_ip_in_subnet,
     requests_from_subnet,
     print_requests_from_subnet,
+    requests_from_browser,
+    print_requests_from_browser,
 )
 
 
@@ -70,5 +73,96 @@ def test_print_requests_from_subnet_returns_number_of_matches(capsys):
 
     assert result == 1
     assert "Requests from subnet 185.0.0.0/10: 1" in captured.out
+    assert "185.23.54.12" in captured.out
+    assert "77.91.204.33" not in captured.out
+
+
+def test_parse_log_line_reads_user_agent():
+    line = (
+        '185.23.54.12 - - [03/Jan/2026:02:14:55 +0100] '
+        '"GET /home HTTP/1.1" 200 1823 "-" '
+        '"Mozilla/5.0 Firefox/120.0"'
+    )
+
+    entry = parse_log_line(line)
+
+    assert entry.user_agent == "Mozilla/5.0 Firefox/120.0"
+
+
+def test_parse_log_line_without_user_agent_still_works():
+    line = (
+        '185.23.54.12 - - [03/Jan/2026:02:14:55 +0100] '
+        '"GET /home HTTP/1.1" 200 1823'
+    )
+
+    entry = parse_log_line(line)
+
+    assert entry.ip == IPv4Address("185.23.54.12")
+    assert entry.user_agent == ""
+
+
+def test_requests_from_browser_returns_only_matching_entries():
+    firefox_entry = LogEntry(
+        "185.23.54.12",
+        datetime(2026, 1, 1),
+        "GET",
+        "/firefox",
+        "HTTP/1.1",
+        200,
+        100,
+        "Mozilla/5.0 Firefox/120.0",
+    )
+
+    chrome_entry = LogEntry(
+        "77.91.204.33",
+        datetime(2026, 1, 1),
+        "GET",
+        "/chrome",
+        "HTTP/1.1",
+        200,
+        100,
+        "Mozilla/5.0 Chrome/120.0",
+    )
+
+    result = requests_from_browser(
+        [firefox_entry, chrome_entry],
+        "Firefox",
+    )
+
+    assert result == [firefox_entry]
+
+
+def test_print_requests_from_browser_prints_only_matching_entries(capsys):
+    firefox_entry = LogEntry(
+        "185.23.54.12",
+        datetime(2026, 1, 1),
+        "GET",
+        "/firefox",
+        "HTTP/1.1",
+        200,
+        100,
+        "Mozilla/5.0 Firefox/120.0",
+    )
+
+    chrome_entry = LogEntry(
+        "77.91.204.33",
+        datetime(2026, 1, 1),
+        "GET",
+        "/chrome",
+        "HTTP/1.1",
+        200,
+        100,
+        "Mozilla/5.0 Chrome/120.0",
+    )
+
+    result = print_requests_from_browser(
+        [firefox_entry, chrome_entry],
+        "Firefox",
+    )
+
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "Requests from browser Firefox: 1" in captured.out
     assert "185.23.54.12" in captured.out
     assert "77.91.204.33" not in captured.out

--- a/tests/test_lab9.py
+++ b/tests/test_lab9.py
@@ -1,0 +1,74 @@
+import os
+import sys
+
+from datetime import datetime
+from ipaddress import IPv4Address
+
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "../src/lab9")),
+)
+
+from lab9 import (
+    LogEntry,
+    subnet_mask_length,
+    is_ip_in_subnet,
+    requests_from_subnet,
+    print_requests_from_subnet,
+)
+
+
+def make_entry(ip_address):
+    return LogEntry(
+        ip_address,
+        datetime(2026, 1, 1),
+        "GET",
+        "/home",
+        "HTTP/1.1",
+        200,
+        100,
+    )
+
+
+def test_subnet_mask_length_for_student_index():
+    assert subnet_mask_length(284210) == 10
+
+
+def test_is_ip_in_subnet_returns_true_for_matching_ip():
+    assert is_ip_in_subnet("185.23.54.12") is True
+
+
+def test_is_ip_in_subnet_returns_false_for_not_matching_ip():
+    assert is_ip_in_subnet("77.91.204.33") is False
+
+
+def test_requests_from_subnet_returns_only_matching_entries():
+    entries = [
+        make_entry("185.23.54.12"),
+        make_entry("77.91.204.33"),
+    ]
+
+    result = requests_from_subnet(entries)
+
+    assert len(result) == 1
+    assert result[0].ip == IPv4Address("185.23.54.12")
+
+
+def test_print_requests_from_subnet_returns_number_of_matches(capsys):
+    entries = [
+        make_entry("185.23.54.12"),
+        make_entry("77.91.204.33"),
+    ]
+
+    result = print_requests_from_subnet(
+        entries,
+        lines_per_page=5,
+        input_func=lambda message: None,
+    )
+
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "Requests from subnet 185.0.0.0/10: 1" in captured.out
+    assert "185.23.54.12" in captured.out
+    assert "77.91.204.33" not in captured.out


### PR DESCRIPTION
Closes #112
Closes #113

Implemented two Lab9 features:

- print requests from a hard-coded subnet
- calculate subnet mask using student index
- use lines_per_page from config for pagination
- print requests from browser defined in config
- added tests for subnet filtering and browser filtering

## How to test

- python3 -m pytest tests/test_lab9.py
- python3 -m py_compile src/lab9/lab9.py